### PR TITLE
chore: Change dependency to work after unencrypted git protocol support dropped

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@nestjs/platform-express": "8.4.0",
     "@nestjs/serve-static": "2.2.2",
     "@nestjs/swagger": "5.2.0",
-    "axios": "git://github.com/zoran995/axios.git#geoportal",
+    "axios": "github:zoran995/axios.git#geoportal",
     "base-x": "4.0.0",
     "class-transformer": "0.5.1",
     "class-validator": "0.13.2",
@@ -96,7 +96,7 @@
     "typescript": "4.6.2"
   },
   "resolutions": {
-    "axios": "git://github.com/zoran995/axios.git#geoportal"
+    "axios": "github:zoran995/axios.git#geoportal"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2380,10 +2380,10 @@ aws-sdk-client-mock@0.6.2:
     sinon "^11.1.1"
     tslib "^2.1.0"
 
-axios@0.26.0, "axios@git://github.com/zoran995/axios.git#geoportal":
+axios@0.26.0, "axios@github:zoran995/axios.git#geoportal":
   version "0.26.0"
   uid "92eb2c86affcf42bf433cf79949440e738bfca28"
-  resolved "git://github.com/zoran995/axios.git#92eb2c86affcf42bf433cf79949440e738bfca28"
+  resolved "https://codeload.github.com/zoran995/axios/tar.gz/92eb2c86affcf42bf433cf79949440e738bfca28"
   dependencies:
     follow-redirects "^1.14.8"
 


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/